### PR TITLE
Fix post excerpts not rendering

### DIFF
--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -3,18 +3,18 @@ import Layout from '../../layouts/Page.astro';
 import BlogPostPreview from '../../components/BlogPostPreview.astro';
 import Paginator from '../../components/Paginator.astro';
 import { getCollection } from 'astro:content';
-import PostExcerpt from '@igor.dvlpr/astro-post-excerpt';  
-  
+import PostExcerpt, { PropHeadings, PropRenderer } from "@igor.dvlpr/astro-post-excerpt";
+
 export async function getStaticPaths({paginate}) {
 
     const posts = await getCollection('blog').then(posts =>
 	posts
-		.map(({ data, slug }) => ({
-            slug: slug,
-			title: data.title,
-			description: data.description,
-			pubDate: data.pubDate,
-            postPreview: data.postPreview,
+		.map((post) => ({
+            slug: post.slug,
+			title: post.data.title,
+			description: post.data.description,
+			pubDate: post.data.pubDate,
+            postPreview: post,
             // imgSrc: data.image.src,
             // imgAlt: data.image.alt,
 		}))
@@ -37,7 +37,7 @@ const { page } = Astro.props;
     <article class="blog-page-content__article">
       <section class="postlist">
         <p class="post-excerpt">
-        {page.data.map((post: any) => <PostExcerpt post={post.postPreview} words={20} addEllipsis={false} />)}
+        {page.data.map((post: any) => <PostExcerpt post={post.postPreview} words={20} addEllipsis={true} headings={PropHeadings.None} /><br><br>)}
         </p>
       </section>
     </article>


### PR DESCRIPTION
By changing the way you transform your posts, I managed to make it work, here's the result:

<div align="center">	
	<img src="https://github.com/tjex/tjex.net/assets/20957750/ceacd3ed-e7a6-46cd-8158-55cc7136bda1" alt="An Astro component that renders post excerpts for your Astro blog">
</div>

<br>

## 🫱🏽‍🫲🏼 Helpful insight

I found a lot of things there are problematic - that need fixing, e.g.

- the prop/field `postPreview` shouldn't even exist, to the `PostExcerpt` you pass the whole post object and then it parses it, now you are passing a string, that's why you got the error you mentioned before,
- your blog loop in `[...page].astro` is wrong, i.e.

```jsx
<article class="blog-page-content__article">
      <section class="postlist"> {/* this should hold all posts (but as separate article elements), now it holds a <p> tag */}
        <p class="post-excerpt"> {/* each blog entry should be wrapped by this */}
        {page.data.map((post: any) => <PostExcerpt post={post.postPreview} words={20} addEllipsis={true} headings={PropHeadings.None} /><br><br>)}
        </p>
      </section>
    </article>
```

Each blog entry should be an `<article>` element and I assume the section with the class **postlist** should hold all blog entries, now it holds all of them as a single entity.

Also, I didn't go too deep but I think your passing of props is wrong as well.

<br>

Anyway, try the changes I did and tell me if it works for you then. 😉